### PR TITLE
Add Defang CI/CD workflow for 3D-Printed-AI-Nerf-Sentry-Turret

### DIFF
--- a/.github/workflows/defang-deploy.yml
+++ b/.github/workflows/defang-deploy.yml
@@ -1,0 +1,44 @@
+name: Defang
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+    inputs:
+      action:
+        description: Whether to deploy up or down
+        required: true
+        default: up
+        type: choice
+        options:
+          - up
+          - down
+      stack:
+        description: The stack to deploy up or down. (Leave blank for default)
+        default: production
+jobs:
+  defang:
+    name: Defang ${{ github.event.inputs.action || 'up' }} ${{ github.event.inputs.stack || 'production' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    concurrency:
+      cancel-in-progress: false
+      group: deploy-3D-Printed-AI-Nerf-Sentry-Turret-${{ github.event.inputs.stack || 'production' }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Defang ${{ github.event.inputs.action || 'up' }} ${{ github.event.inputs.stack || 'production' }}
+        uses: DefangLabs/defang-github-action@v1
+        with:
+          command: ${{ github.event.inputs.action || 'up' }}
+          project: 3D-Printed-AI-Nerf-Sentry-Turret
+          stack: ${{ github.event.inputs.stack || 'production' }}
+      - name: Deployment Summary
+        uses: DefangLabs/defang-github-action@v1
+        with:
+          command: services
+          project: 3D-Printed-AI-Nerf-Sentry-Turret
+          stack: ${{ github.event.inputs.stack || 'production' }}
+    environment: defang-production


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to deploy **3D-Printed-AI-Nerf-Sentry-Turret** using [Defang](https://defang.io).

## What's included

- `.github/workflows/defang-deploy.yml` — deploys on push to `master`
- Environment: `production`
- Manual dispatch support (deploy up/down)

## Next steps

1. **Review and merge** this PR
2. Push to `master` to trigger your first deployment
3. Monitor the deployment in the [Defang Portal](https://portal.defang.dev)

---
*Created by the Defang GitHub App*