### PR TITLE
Add Defang CI/CD workflow for production3

### DIFF
--- a/.github/workflows/defang.yaml
+++ b/.github/workflows/defang.yaml
@@ -1,0 +1,45 @@
+name: Defang
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+    inputs:
+      action:
+        description: Whether to deploy up or down
+        required: true
+        default: up
+        type: choice
+        options:
+          - up
+          - down
+      stack:
+        description: The stack to deploy up or down. (Leave blank for default)
+        default: production3
+jobs:
+  defang:
+    name: Defang ${{ github.event.inputs.action || 'up' }} ${{ github.event.inputs.stack || 'production3' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 70
+    permissions:
+      contents: read
+      id-token: write
+    concurrency:
+      cancel-in-progress: false
+      group: deploy-3D-Printed-AI-Nerf-Sentry-Turret-${{ github.event.inputs.stack || 'production3' }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Defang ${{ github.event.inputs.action || 'up' }} ${{ github.event.inputs.stack || 'production3' }}
+        uses: DefangLabs/defang-github-action@v2
+        with:
+          command: ${{ github.event.inputs.action || 'up' }}
+          project: 3D-Printed-AI-Nerf-Sentry-Turret
+          stack: ${{ github.event.inputs.stack || 'production3' }}
+      - name: Deployment Summary
+        uses: DefangLabs/defang-github-action@v2
+        with:
+          command: services
+          project: 3D-Printed-AI-Nerf-Sentry-Turret
+          stack: ${{ github.event.inputs.stack || 'production3' }}
+    environment: defang-production3


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to deploy **3D-Printed-AI-Nerf-Sentry-Turret** for the stack: `production3` using [Defang](https://defang.io).

## What's included

- `.github/workflows/defang.yaml` — deploys on push to `master`
- Stack: `production3`
- Environment: `defang-production3` - authorizes the deployment and is used for config
- Manual dispatch support (deploy up/down)

## Next steps

1. **Review and merge** this PR
2. Push to `master` to trigger your first deployment
3. Monitor the deployment in the [Defang Portal](https://portal.defang.dev)

---
*Created by the Defang GitHub App*